### PR TITLE
Bump linked_hashmap to 0.5.3+

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ categories = ["algorithms", "caching", "data-structures"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-linked-hash-map = "0.5"
+linked-hash-map = "0.5.3"


### PR DESCRIPTION
Linked_hash_map is unsound for releases <= 0.5.2. Bumping this to ^0.5.3

[Advisory](https://github.com/RustSec/advisory-db/issues/298)